### PR TITLE
商品情報編集機能完了

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,6 @@
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
-  before_action :set_message, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
 
   def index
     @items = Item.all.order(created_at: :desc)

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :move_to_index, except: [:index, :show]
+  before_action :set_message, only: [:show, :edit, :update]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -19,16 +20,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to new_user_session_path unless user_signed_in? && current_user.id == @item.user_id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to root_path
     else
@@ -44,5 +42,9 @@ class ItemsController < ApplicationController
 
   def move_to_index
     redirect_to new_user_session_path unless user_signed_in?
+  end
+
+  def set_message
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,8 +29,11 @@ class ItemsController < ApplicationController
 
   def update
     @item = Item.find(params[:id])
-    @item.update(item_params)
-    redirect_to root_path
+    if @item.update(item_params)
+      redirect_to root_path
+    else
+      render :edit
+    end
   end
 
   private

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -22,6 +22,17 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+    redirect_to new_user_session_path unless user_signed_in? && current_user.id == @item.user_id
+  end
+
+  def update
+    @item = Item.find(params[:id])
+    @item.update(item_params)
+    redirect_to root_path
+  end
+
   private
 
   def item_params
@@ -29,8 +40,6 @@ class ItemsController < ApplicationController
   end
 
   def move_to_index
-    unless user_signed_in?
-      redirect_to new_user_session_path
-    end
+    redirect_to new_user_session_path unless user_signed_in?
   end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -13,5 +13,4 @@ class Category < ActiveHash::Base
   ]
   include ActiveHash::Associations
   has_many :items
-
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -14,21 +14,18 @@ class Item < ApplicationRecord
 
   def image_presence
     if image.attached?
-      if !image.content_type.in?(%('image/jpeg image/png'))
-        errors.add(:image, 'にはjpegまたはpngファイルを添付してください')
-      end
+      errors.add(:image, 'にはjpegまたはpngファイルを添付してください') unless image.content_type.in?(%('image/jpeg image/png'))
     else
       errors.add(:image, 'ファイルを添付してください')
     end
   end
-  
+
   with_options presence: true do
     validates :item_name
     validates :description
-    validates :price, format: { with: /\A[0-9]+\z/},
-    numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999, message: '入力値が¥300~¥9,999,999の範囲外です'}
-                
-                 
+    validates :price, format: { with: /\A[0-9]+\z/ },
+                      numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: '入力値が¥300~¥9,999,999の範囲外です' }
+
     with_options numericality: { other_than: 1 } do
       validates :category_id
       validates :status_id

--- a/app/models/prefecture.rb
+++ b/app/models/prefecture.rb
@@ -1,22 +1,22 @@
 class Prefecture < ActiveHash::Base
   self.data = [
-    {id: 1, name: '--'},
-    {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
-    {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
-    {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
-    {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
-    {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
-    {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
-    {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
-    {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
-    {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
-    {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
-    {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
-    {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
-    {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
-    {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
-    {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
-    {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+    { id: 1, name: '--' },
+    { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
+    { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },
+    { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' }, { id: 13, name: '千葉県' },
+    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' },
+    { id: 20, name: '山梨県' }, { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' },
+    { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, { id: 25, name: '三重県' },
+    { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, { id: 31, name: '和歌山県' },
+    { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' }, { id: 34, name: '岡山県' },
+    { id: 35, name: '広島県' }, { id: 36, name: '山口県' }, { id: 37, name: '徳島県' },
+    { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, { id: 43, name: '長崎県' },
+    { id: 44, name: '熊本県' }, { id: 45, name: '大分県' }, { id: 46, name: '宮崎県' },
+    { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
   include ActiveHash::Associations

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,21 +8,21 @@ class User < ApplicationRecord
   VALID_PASSWORD_REGEX = /\A(?=.*?[a-z])(?=.*?\d)[a-z\d]+\z/i.freeze
   VALID_NAME_REGEX = /\A[ぁ-んァ-ン一-龥]+\z/.freeze
   VALID_NAME_KANA_REGEX = /\A[ァ-ヶー－]+\z/.freeze
-  
+
   with_options presence: true do
     validates :nickname
     validates :birth_day
-    
+
     with_options format: { with: VALID_NAME_REGEX, message: 'はひらがな、カタカナ、漢字で入力してください。' } do
-      validates :first_name 
+      validates :first_name
       validates :last_name
     end
     with_options format: { with: VALID_NAME_KANA_REGEX, message: 'はカタカナで入力して下さい。' } do
-      validates :first_name_kana 
+      validates :first_name_kana
       validates :last_name_kana
     end
   end
-  
-  validates :password, length: { minimum: 6 , message: 'は6文字以上入力してください。' },
+
+  validates :password, length: { minimum: 6, message: 'は6文字以上入力してください。' },
                        format: { with: VALID_PASSWORD_REGEX }
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,9 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
+    <%= form_with model: @item, url: item_path, local: true do |f| %>
 
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 出品画像 %>
     <div class="img-upload">
@@ -23,7 +21,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /出品画像 %>
@@ -33,13 +31,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :description, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +50,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:status_id, Status.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +71,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:days_to_ship_id, DaysToShip.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +99,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +139,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path(@item.id), class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
 
-      <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
+      <%= link_to '商品の編集', edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
       <p class='or-text'>or</p>
       <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
     <% elsif user_signed_in? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
 root to: 'items#index'
-resources :items, only: [:index, :new, :create, :show]
+resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,18 +1,17 @@
 FactoryBot.define do
   factory :item do
-    item_name              {Faker::Name.last_name}
-    description            {Faker::Lorem.sentence}
-    category_id            {2}
-    status_id              {2}
-    shipping_cost_id       {2}
-    prefectures_id         {2}
-    days_to_ship_id        {2}
-    price                  {222222}
+    item_name              { Faker::Name.last_name }
+    description            { Faker::Lorem.sentence }
+    category_id            { 2 }
+    status_id              { 2 }
+    shipping_cost_id       { 2 }
+    prefectures_id         { 2 }
+    days_to_ship_id        { 2 }
+    price                  { 222_222 }
     association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('app/assets/images/furima-intro01.png'), filename: 'test_image.png')
     end
-    
   end
 end

--- a/spec/factories/purchases.rb
+++ b/spec/factories/purchases.rb
@@ -1,5 +1,4 @@
 FactoryBot.define do
   factory :purchase do
-    
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :user do
     nickname              { 'yosida' }
-    email                 {Faker::Internet.free_email}
-    password              {'111aaa'}
+    email                 { Faker::Internet.free_email }
+    password              { '111aaa' }
     password_confirmation { password }
     last_name             { '吉田' }
     first_name            { '香織' }

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe Item, type: :model do
   describe '商品出品登録機能'
   it '必要項目を入力し、商品登録ができる' do
     expect(@item).to be_valid
-
   end
   it 'item_nameが空だと登録できない' do
     @item.item_name = nil
@@ -28,7 +27,7 @@ RSpec.describe Item, type: :model do
   it 'category_idに1が選択されている場合は保存できない' do
     @item.category_id = 1
     @item.valid?
-    expect(@item.errors.full_messages).to include("Category must be other than 1")
+    expect(@item.errors.full_messages).to include('Category must be other than 1')
   end
   it 'status_idが空だと登録できない' do
     @item.status_id = nil
@@ -43,7 +42,7 @@ RSpec.describe Item, type: :model do
   it 'shipping_cost_idに1が選択されている場合は保存できない' do
     @item.shipping_cost_id = 1
     @item.valid?
-    expect(@item.errors.full_messages).to include("Shipping cost must be other than 1")
+    expect(@item.errors.full_messages).to include('Shipping cost must be other than 1')
   end
   it 'prefecture_idが空だと登録できない' do
     @item.prefecture_id = nil
@@ -53,7 +52,7 @@ RSpec.describe Item, type: :model do
   it 'prefecture_idに1が選択されている場合は保存できない' do
     @item.prefectures_id = 1
     @item.valid?
-    expect(@item.errors.full_messages).to include("Prefecture must be other than 1")
+    expect(@item.errors.full_messages).to include('Prefecture must be other than 1')
   end
   it 'days_to_ship_idが空だと登録できない' do
     @item.days_to_ship_id = nil
@@ -63,7 +62,7 @@ RSpec.describe Item, type: :model do
   it 'days_to_ship_idに1が選択されている場合は保存できない' do
     @item.days_to_ship_id = 1
     @item.valid?
-    expect(@item.errors.full_messages).to include("Days to ship must be other than 1")
+    expect(@item.errors.full_messages).to include('Days to ship must be other than 1')
   end
   it 'priceが空だと登録できない' do
     @item.price = nil
@@ -73,21 +72,21 @@ RSpec.describe Item, type: :model do
   it 'priceの値が300~9,999,999でないと登録できない' do
     @item.price = 200
     @item.valid?
-    expect(@item.errors.full_messages).to include("Price 入力値が¥300~¥9,999,999の範囲外です")
+    expect(@item.errors.full_messages).to include('Price 入力値が¥300~¥9,999,999の範囲外です')
   end
   it 'priceの値が300~9,999,999でないと登録できない' do
-    @item.price = 10000000
+    @item.price = 10_000_000
     @item.valid?
-    expect(@item.errors.full_messages).to include("Price 入力値が¥300~¥9,999,999の範囲外です")
+    expect(@item.errors.full_messages).to include('Price 入力値が¥300~¥9,999,999の範囲外です')
   end
   it 'priceが全角数字だと登録できない' do
-    @item.price = "１２３４"
+    @item.price = '１２３４'
     @item.valid?
-    expect(@item.errors.full_messages).to include("Price 入力値が¥300~¥9,999,999の範囲外です")
+    expect(@item.errors.full_messages).to include('Price 入力値が¥300~¥9,999,999の範囲外です')
   end
   it 'imageが空だと登録できない' do
     @item.image = nil
     @item.valid?
-    expect(@item.errors.full_messages).to include("Image ファイルを添付してください")
+    expect(@item.errors.full_messages).to include('Image ファイルを添付してください')
   end
 end


### PR DESCRIPTION
# what
- 商品情報編集機能の実装
- 何も編集せずに更新をしても画像無しの商品にならないこと
https://gyazo.com/7832bbabffacf2cdfcf68be24ffe3809
- ログイン状態の出品者だけが商品情報編集ページに遷移できること
https://gyazo.com/bf740225af9430ff8c72565f1a73899a
- ログイン状態の出品者以外のユーザーは、URLを直接入力して出品していない商品の商品情報編集ページへ遷移しようとするとトップページに遷移すること
https://gyazo.com/8207f0ba84c0dc8aac4bddcc020d1880
- 商品出品時とほぼ同じ見た目で商品情報編集機能が実装されていること
- 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示されること（画像に関 
 しては、表示されない状態で良い）
https://gyazo.com/73a6cec00847486217865b3309a9ac58
- エラーハンドリングができていること（適切では無い値が入力された場合、情報は保存されず、エラーメッセージを出力させること）
- エラーメッセージの出力は、商品情報編集ページにて行うこと
https://gyazo.com/862f803a71acaae59baf576ee1311619

# why
商品情報編集機能を使用するため